### PR TITLE
change dot parser to parsercombinator DOT

### DIFF
--- a/src/PlotGraphviz.jl
+++ b/src/PlotGraphviz.jl
@@ -2,7 +2,7 @@ module PlotGraphviz
 
 using Graphs
 using SimpleWeightedGraphs
-using Tokenize
+using ParserCombinator
 using ShowGraphviz
 
 
@@ -11,14 +11,17 @@ using ShowGraphviz
 
 export
     # visualization mit Graphviz (for small graphs or use file_export:)
-    plot_graphviz, write_dot_file, read_dot_file, AttributeDict, set!, val, rm!
+    plot_graphviz, write_dot_file, read_dot_file, GraphvizAttributes,
+    set!, val, rm!,
+    set_edge!, set_node!, val_edge, val_node, get_id, get_node,
+    Property, Attributes, gvNode, Nodes, gvEdge, gvEdges
 
 
 include("./dots/attributes.jl")
+include("./dots/graph_attributes.jl")
 include("./dots/import_dots.jl")
 include("./dots/export_dots.jl")
 include("./dots/plot_graphviz.jl")
 include("./dots/to_dot.jl")
-
 
 end

--- a/src/dots/attributes.jl
+++ b/src/dots/attributes.jl
@@ -1,116 +1,52 @@
 
 
+abstract type GraphvizPoperties end
 
-#typealias
-const AttributeDict = Dict{Any,Array{Tuple{String,Any}}}
-
-"""
-    default_attributes(g)
-
-Return `attrs::AttributeDict default` as plotting paramter for `GraphViz` Plot.
-
-See attributes on http://www.graphviz.org/. The AttributeDict is of `Dict{Symbol,Vector{String}}` with Symbols `P` (Plot), `G` (Graph), `N` (Node) and `E` (Edges).
-For example the following dict-Entry set the layout engine to `dot`.
-
-    attr[:layout] = ["G", "dot"]
-
-#### Arguments
-- `g::AbstractSimpleWeightedGraph`: a graph representation to export 
-"""
-function get_attributes(graph::AbstractSimpleWeightedGraph; node_label::Bool = true, edge_label::Bool = false)
-    directed = Graphs.is_directed(graph)
-    n = nv(graph)
-    #size_graph=minimum(5.0 +*/sqrt, 15.0)  # ToDo: automated scaler
-    attr = AttributeDict(
-        "P" => [
-            ("weights", (edge_label) ? "true" : "false"),
-            ("largenet", "200")],
-        "G" => [
-            ("center", "1"),
-            ("overlap", "scale"),
-            ("concentrate", "true"),
-            ("layout", (directed) ? "dot" : "neato"),
-            ("size", (n < 20) ? "3.0" : ((n < 100) ? "7.0" : "10.0"))],
-        "N" => [
-            ("color", "Turquoise"),
-            ("fontsize", (node_label) ? ((n < 100) ? "7.0" : "5.0") : "1.0"),
-            ("width", (node_label) ? "0.25" : "0.20"),
-            ("height", (node_label) ? "0.25" : "0.20"),
-            ("fixedsize", "true"), ("shape", (node_label) ? "circle" : "point")],
-        "E" => [
-            ("arrowsize", "0.5"),
-            ("arrowtype", "normal"),
-            ("fontsize", (edge_label) ? "8.0" : "1.0")
-        ])
-    if n > parse(Int64, val(attr["P"], "largenet"))
-        attr = _mod_attr_large_network!(attr)
-    end
-
-    return attr
+mutable struct Property{T} 
+    key::String
+    value::T
 end
 
-# internal function to modify `GraphViz` plot-paramter for large graphs
-function _mod_attr_large_network!(attrs::AttributeDict)
-    set!(attrs["N"], "shape", "point")
-    set!(attrs["N"], "color", "black")
-    set!(attrs["G"], "fontsize", "1")
-    set!(attrs["G"], "concetrate", "true")
-    set!(attrs["G"], "layout", "sfdp")
-    set!(attrs["P"], "weights", "false")
-    set!(attrs["N"], "shape", "point")
-end
+
+const Properties = Vector{Property}
 
 # return val of attribute:
-function val(attributes::Array{Tuple{String,Any}}, attribute::String)
+function val(attributes::Properties, attribute::String)
     if !isempty(attributes)
         for a in attributes
-            if a[1] == attribute
-                return a[2]
+            if a.key == attribute
+                return a.value
             end
         end
     end
     return []
 end
 
-# set val to attributeDict
-function set!(attrs::AttributeDict, key, attribute::Tuple{String,Any})
-    if haskey(attrs, key)
-        set!(attrs[key], attribute[1], attribute[2])
-    else
-        attrs[key] = [attribute]
-    end
-end
-
-# set val of attribute:
-function set!(attributes::Array{Tuple{String,Any}}, attribute::String, val)
-    if isempty(attributes)
-        push!(attributes, (attribute, val))
-    else
+# return Tuple (bool, pos). bool=true if key exist in Attributes
+import Base.haskey
+function haskey(attributes::Properties, key::String)
+    if !isempty(attributes)
         for i = 1:length(attributes)
-            if (attributes[i][1] == attribute) && !(attributes[i][2] == val)
-                attributes[i] = (attribute, val)
-                return attributes
-            elseif (attributes[i][1] == attribute) && (attributes[i][2] == val)
-                return attributes
+            if attributes[i].key == key
+                return true, i
             end
         end
-        push!(attributes, (attribute, val))
     end
-    return attributes
+    return false, 0
+end
+
+# set val to attributeDict
+function set!(attributes::Properties, key::String, value)
+    key_exist, idx = haskey(attributes, key)
+    if key_exist
+        attributes[idx].value = value
+    else
+        push!(attributes, Property(key, value))
+    end
 end
 
 # remove attribute of attributes
-function rm!(attributes::Array{Tuple{String,Any}}, attribute::String)
-    if !isempty(attributes)
-        for i = 1:length(attributes)
-            if attributes[i] == attribute
-                attributes = deleteat!(attributes, i)
-                return attributes
-            end
-        end
-    end
-    return attributes
+function rm!(attributes::Properties, key::String)
+    key_exist, idx = haskey(attributes, key)
+    (key_exist) ? deleteat!(attributes, idx) : nothing
 end
-
-
-

--- a/src/dots/export_dots.jl
+++ b/src/dots/export_dots.jl
@@ -12,8 +12,34 @@ Export graph `g` to DOT-Format and store it in file `file`.
 - (optional) `colors = zeros(Int, nv(mat))`: Components-colors vector representated by a color number each node.
 """
 function write_dot_file(graph::AbstractSimpleWeightedGraph, filename::AbstractString;
-    attributes::AttributeDict = get_attributes(graph), path = [], colors = zeros(Int, nv(graph)))
-    open(filename, "w") do f
-        _to_dot(graph, f, attributes, path, colors)
+    attrs = GraphvizAttributes(graph), path = [], colors = zeros(Int, nv(graph)))
+
+    if !isempty(path)
+        color_path!(attrs, path, graph)
     end
+
+    if (!is_all_zero(colors))
+        color_nodes!(attrs, colors)
+    end
+
+    open(filename, "w") do f
+        dot(graph, f, attrs)
+    end
+end
+
+
+# internal function to get the dot representation of a graph as a string.
+function string_dot(graph::AbstractSimpleWeightedGraph, attributes = GraphvizAttributes(g), path = [], colors = zeros(Int, nv(g)))
+
+    if !isempty(path)
+        color_path!(attributes, path, graph)
+    end
+
+    if (!is_all_zero(colors))
+        color_nodes!(attributes, colors)
+    end
+
+    str = IOBuffer()
+    dot(graph, str, attributes)
+    String(take!(str)) #takebuf_string(str)
 end

--- a/src/dots/graph_attributes.jl
+++ b/src/dots/graph_attributes.jl
@@ -1,0 +1,210 @@
+
+struct gvNode <: GraphvizPoperties
+    id::Int64
+    name::String
+    attributes::Properties
+end
+
+gvNode(id::Int64) = gvNode(id, String(id), Properties())
+
+const gvNodes = Vector{gvNode}
+
+struct gvEdge <: GraphvizPoperties
+    from::Int
+    to::Int
+    attributes::Properties
+end
+
+gvEdge(from::Int, to::Int) = gvEdge(from, to, Properties())
+
+const gvEdges = Vector{gvEdge}
+
+
+struct gvSubGraph
+    type::String
+    plot_options::Properties
+    graph_options::Properties
+    node_options::Properties
+    edge_options::Properties
+    nodes::gvNodes
+    edges::gvEdges
+end
+
+# empty outer constructor:
+function gvSubGraph(type::String)
+    type = type
+    plot_options = Properties()
+    graph_options = Properties()
+    node_options = Properties()
+    edge_options = Properties()
+    node = gvNodes()
+    edges = gvEdges()
+
+    return gvSubGraph(type, plot_options, graph_options, node_options, edge_options, node, edges)
+end
+
+const gvSubGraphs = Vector{gvSubGraph}
+
+# the main struct!
+struct GraphvizAttributes
+    plot_options::Properties
+    graph_options::Properties
+    node_options::Properties
+    edge_options::Properties
+    subgraphs::gvSubGraphs
+    nodes::gvNodes
+    edges::gvEdges
+end
+
+# empty outer constructor:
+function GraphvizAttributes()
+    plot_options = Properties()
+    graph_options = Properties()
+    node_options = Properties()
+    edge_options = Properties()
+    subgraphs = gvSubGraphs()
+    node = gvNodes()
+    edges = gvEdges()
+
+    return GraphvizAttributes(plot_options, graph_options, node_options, edge_options, subgraphs, node, edges)
+end
+
+# derived from SimpleWeightedGraph
+function GraphvizAttributes(graph::AbstractSimpleWeightedGraph; node_label::Bool = true, edge_label::Bool = false)
+    directed = Graphs.is_directed(graph)
+    n = nv(graph)
+    large_graph = 200
+
+    plot_options = [Property("weights", (edge_label) ? "true" : "false"),
+        Property("largenet", "200")]
+
+    graph_options = [Property("center", "\"1,1\""),
+        Property("overlap", "scale"),
+        Property("concentrate", "true"),
+        Property("layout", (directed) ? "dot" : "neato"),
+        Property("size", (n < 20) ? "3.0" : ((n < 100) ? "7.0" : "10.0"))]  # scaling function missing!
+    node_options = [Property("color", "Turquoise"),
+        Property("fontsize", (node_label) ? ((n < 100) ? "7.0" : "5.0") : "1.0"),
+        Property("width", (node_label) ? "0.25" : "0.20"),
+        Property("height", (node_label) ? "0.25" : "0.20"),
+        Property("fixedsize", "true"),
+        Property("shape", (node_label) ? "circle" : "point")]
+    edge_options = [Property("arrowsize", "0.5"),
+        Property("arrowtype", "normal"),
+        Property("fontsize", (edge_label) ? "8.0" : "1.0")]
+
+    nodes = [gvNode(i, "$i", Properties()) for i = 1:n]
+
+    edges = []
+    for i = 1:n, j = 1:n
+        if !(graph.weights[i, j] == 0)
+            push!(edges, gvEdge(i, j, [Property("xlabel", graph.weights[i, j])]))
+        end
+    end
+
+    # modifier by large networks:
+    # if n > large_graph
+    #    attr = _mod_attr_large_network!(attr)
+    # end
+
+    return GraphvizAttributes(plot_options, graph_options, node_options, edge_options, gvSubGraphs(), nodes, edges)
+end
+
+# setter
+function set_edge!(edges::gvEdges, from::Int, to::Int, attribute::Property)
+    if !isempty(edges)
+        for e in edges
+            if (e.from == from) && (e.to == to)
+                set!(e.attributes, attribute.key, attribute.value)
+            end
+        end
+    else
+        push!(edges, gvEdge(from, to, [attribute]))
+    end
+end
+
+
+function set_node!(nodes::gvNodes, id::Int, attribute::Property)
+    if !isempty(nodes)
+        for n in nodes
+            if n.id == id
+                set!(n.attributes, attribute.key, attribute.value)
+            end
+        end
+    else
+        push!(nodes, gvNode(id, String(id), [attribute]))
+    end
+end
+
+# getter:
+function val_edge(edges::gvEdges, from::Int, to::Int, key::String)
+    if !isempty(edges)
+        for e in edges
+            if (e.from == from) && (e.to == to)
+                return val(e.attributes, key)
+            end
+        end
+    end
+    return []
+end
+
+function val_node(nodes, id::Int64, key::String)
+    if !isempty(nodes)
+        for n in nodes
+            if n.id == id
+                return val(n.attributes, key)
+            end
+        end
+    end
+    return []
+end
+
+# special functions
+
+function _get_label(nodes::gvNodes, id::Int64)
+    if !isempty(nodes)
+        for n in nodes
+            if n.id == id
+                label = val(n.attributes, "label")
+                if !isempty(label)
+                    return label
+                end
+            end
+        end
+    end
+    return []
+end
+
+# get max (number of node) id of nodes
+function _max_id(nodes::gvNodes)
+    max = 0
+    if !isempty(nodes)
+        for n in nodes
+            (n.id > max) ? max = n.id : nothing
+        end
+    end
+    return max
+end
+
+# return id from node_label!
+function get_id(nodes, str)
+    if !isempty(nodes)
+        for n in nodes
+            #  labl = val_node(nodes, n.id, "label")
+            if n.name == str
+                return n.id
+            end
+        end
+    end
+    return 0
+end
+
+function get_node(nodes::gvNodes, id::Int)
+    for node in nodes
+        if node.id == id
+            return node
+        end
+    end
+    return []
+end
+

--- a/src/dots/plot_graphviz.jl
+++ b/src/dots/plot_graphviz.jl
@@ -1,6 +1,4 @@
 
-
-
 """
     plot_graphviz(g, node_label= true, edge_label=false; path = zeros(Int, nv(mat))
 
@@ -9,28 +7,27 @@ Render graph `g` in iJulia using `Graphviz` engines.
 
 #### Arguments
 - `g::AbstractSimpleWeightedGraph`: a graph representation to export 
-- `node_label::Bool`: if true all nodes are numberd fom 1:N (default = true)
-- `edge_label::Bool`: if true all edges are labeled with their weights (default = false)
+- (optional) `node_label::Bool`: if true all nodes are numberd fom 1:N (default = true)
+- (optional) `edge_label::Bool`: if true all edges are labeled with their weights (default = false)
 - (optional) `path = []`: Int-Array of nodes. Nodes and their edges are drawn in red color (i.e. shortest path)
 - (optional) `colors = zeros(Int, nv(mat))`: Color nodes using Brewer Color Scheme (max 9 colors).
 - (optional) `scale = 3.0`: Scale your plot
 - (optional) `landscape = false`: render landscape, but node-labes are not rotated as well.
 """
 function plot_graphviz(g::AbstractSimpleWeightedGraph;
-    node_label::Bool = true,
     edge_label::Bool = false,
     colors = zeros(Int, SimpleWeightedGraphs.nv(g)),
     path = [],
     scale = 3.0,
     landscape = false)
 
-    attributes = get_attributes(g; node_label = node_label, edge_label = edge_label)
-    set!(attributes["G"], "size", string(scale))
-    (edge_label) ? set!(attributes["G"], "forcelabels", "true") : nothing
-    (landscape) ? set!(attributes["G"], "orientation", "LR") : nothing
+    attrs = GraphvizAttributes(g; node_label = true, edge_label = edge_label)
+    set!(attrs.graph_options, "size", string(scale))
 
+    (edge_label) ? set!(attrs.graph_options, "forcelabels", "true") : nothing
+    (landscape) ? set!(attrs.graph_options, "rankdir", "LR") : nothing
 
-    gv_dot = _to_dot(g, attributes, path, colors)
+    gv_dot = string_dot(g, attrs, path, colors)
     plot_graphviz(gv_dot)
 end
 
@@ -48,19 +45,20 @@ Render graph `g` in **iJulia** using `Graphviz` engines.
 - (optional) `colors = zeros(Int, nv(mat))`: Color nodes using Brewer Color Scheme (max 9 colors).
 - (optional) `scale = 3.0`: Scale your plot
 """
-function plot_graphviz(g::AbstractSimpleWeightedGraph, attributes::AttributeDict;
+function plot_graphviz(g::AbstractSimpleWeightedGraph, attributes::GraphvizAttributes;
     path = [],
     colors = zeros(Int, nv(g)),
     scale = 3.0
 )
-    if !isempty(val(attributes["P"], "weights"))
-        (val(attributes["P"], "weights") == "true") ? set!(attributes["G"], "forcelabels", "true") : nothing
+    if !isempty(val(attributes.plot_options, "weights"))
+        (val(attributes.plot_options, "weights") == "true") ? set!(attributes.graph_options, "forcelabels", "true") : nothing
     end
-    set!(attributes["G"], "size", string(scale))
-    gv_dot = _to_dot(g, attributes, path, colors)
+    set!(attributes.graph_options, "size", string(scale))
+    gv_dot = string_dot(g, attributes, path, colors)
     plot_graphviz(gv_dot)
 end
 
+# call ShowGraphviz
 function plot_graphviz(str::AbstractString)
     ShowGraphviz.CONFIG.dot_option = `-q` # do not warn in iJulia!
     ShowGraphviz.DOT(str)

--- a/src/dots/to_dot.jl
+++ b/src/dots/to_dot.jl
@@ -8,162 +8,106 @@
 # https://github.com/tkf/ShowGraphviz.jl
 # and only simply modified (Roettgermann, 12/21)
 
-# internal function to get a suitable string out of the attribute dictionary:
-function _parse_attributes(attrs::AttributeDict, gne::String)
-    str_attr::String = ""
-    if haskey(attrs, gne)
-        gne_attrs = attrs[gne] # _get_GNE_attributes(attrs, gne)
+
+# internal helper functions
+to_dot(sym::String, value::Any) = "$sym=$value"
+edge_op(graph::AbstractSimpleWeightedGraph) = Graphs.is_directed(graph) ? "->" : "--"
+parse_attributes(attributes) = string("[", join(map(a -> to_dot(a.key, a.value), attributes), ","))
+is_all_zero(arr) = length(arr) == 0 || all(==(0), arr)
 
 
-        if contains(gne, "N") # node attributes
-            str_attr = string("[", join(map(a -> _to_dot(a[1], a[2]), collect(gne_attrs)), ","))
-        elseif contains(gne, "G") # graph attributes
-            for key in gne_attrs
-                str_attr = str_attr * string(_to_dot(key[1], key[2]), ";\n ")
-            end
-        elseif contains(gne, "E") # edge attributes
-            str_attr = string("[", join(map(a -> _to_dot(a[1], a[2]), collect(gne_attrs)), ","))
-        end
-    end
-    return str_attr
-end
-
-# internal functions to identify strings:
-_to_dot(sym::String, value::Any) = "$sym=$value"
-_graph_type_string(graph::AbstractSimpleWeightedGraph) = Graphs.is_directed(graph) ? "digraph" : "graph"
-_edge_op(graph::AbstractSimpleWeightedGraph) = Graphs.is_directed(graph) ? "->" : "--"
-
-
-
-function _to_dot_graph_attributes(g::AbstractSimpleWeightedGraph, stream::IO, attrs::AttributeDict)
+function dot(g::AbstractSimpleWeightedGraph, stream::IO, attrs::GraphvizAttributes)
 
     # write beginning: graph or digraph:
-    graph_type_string = Graphs.is_directed(g) ? "digraph" : "graph"
-    write(stream, "$graph_type_string {\n")
-    set!(attrs, "P", ("type", graph_type_string))
+    directed = Graphs.is_directed(g)
 
-    # write general attributes, belongs to all elements:
-    G = "G"
-    write(stream, " $(_parse_attributes(attrs, G))\n")
+    graph_type_string = directed ? "digraph" : "graph"
+    write(stream, "$graph_type_string G {\n")
 
-    N = "N"
-    str_N = _parse_attributes(attrs, N)
-    if !isempty(strip(str_N))
-        write(stream, " node $str_N];\n")
+    set!(attrs.plot_options, "type", graph_type_string)
+    set!(attrs.graph_options, "concentrate", "true")
+    # set!(attrs.graph_options, "layout", (directed) ? "dot" : "neato")
+
+    # write GENERAL attributes, belongs to all elements:
+    write(stream, " graph$(parse_attributes(attrs.graph_options))]\n")
+    write(stream, " node$(parse_attributes(attrs.node_options))]\n")
+    write(stream, " edge$(parse_attributes(attrs.edge_options))]\n")
+
+
+    # write subgraphs (todo)
+    if !isempty(attrs.subgraphs)
+        for subgraph in attrs.subgraphs
+            write(stream, "subgraph $(subgraph.type) { \n")
+
+            write(stream, " graph$(parse_attributes(subgraph.graph_options))]\n")
+            write(stream, " node$(parse_attributes(subgraph.node_options))]\n")
+            write(stream, " edge$(parse_attributes(subgraph.edge_options))]\n")
+
+            # write node 
+            for n in subgraph.nodes
+                write(stream, " $(n.id) $(parse_attributes(n.attributes))];\n")
+            end
+
+            # write edges
+            for e in subgraph.edges
+                write(stream, " $(e.from) $(edge_op(g)) $(e.to) $(parse_attributes(e.attributes))];\n")
+            end
+
+            write(stream, "}\n")
+        end
     end
 
-    E = "E"
-    str_E = _parse_attributes(attrs, E)
-    if !(isempty(strip(str_E)))
-        write(stream, " edge $str_E];\n")
+
+    # write node 
+    for n in attrs.nodes
+        write(stream, " $(n.id) $(parse_attributes(n.attributes))];\n")
     end
+
+    # write edges
+    for e in attrs.edges
+        write(stream, " $(e.from) $(edge_op(g)) $(e.to) $(parse_attributes(e.attributes))];\n")
+    end
+
+    write(stream, "}\n")
+    return stream
 end
 
 
-function _to_dot_node_attributes(g::AbstractSimpleWeightedGraph, stream::IO, attrs::AttributeDict, path, colors)
+function color_nodes!(attrs::GraphvizAttributes, colors)
 
     # hard-coded color scheme:
-    color_scheme = "colorscheme=set19"
-
-    (!isempty(path)) ? show_path = true : show_path = false
-    (!_is_all_zero(colors)) ? show_color = true : show_color = false
-    (show_color == true) ? write(stream, " node [$color_scheme]\n\n") : nothing
-
-    # iter:
-    for node = 1:nv(g)
-
-        # get node specific attributes:
-        n_attrs = _parse_attributes(attrs, "N$node")
-
-
-        if show_color && (colors[node] > 0)
-            (!isempty(n_attrs)) ? n_attrs = n_attrs * "," : n_attrs = "["
-            n_attrs = n_attrs * "color=$(colors[node])"
-        end
-
-        if show_path && !Base.isnothing(findfirst(isequal(node), path))
-            (!isempty(n_attrs)) ? n_attrs = n_attrs * "," : n_attrs = "["
-            n_attrs = n_attrs * "fillcolor=red"
-        end
-
-        (!isempty(n_attrs)) ? n_attrs = n_attrs * "]" : n_attrs = n_attrs * ";"
-
-        write(stream, "$node$n_attrs\n")
-    end
-end
-
-function _to_dot_edge_attributes(g::AbstractSimpleWeightedGraph, stream::IO, attrs::AttributeDict, path, colors)
-
-    # check if `weighted` and labeled:
-    # if has_attribute(attrs, "weights")
-    attr_ = val(attrs["P"], "weights")
-    (attr_ == "true") ? edge_label = true : edge_label = false
-    # end
-
-    # check if colored or path:
-    (!isempty(path)) ? show_path = true : show_path = false
-    (!_is_all_zero(colors)) ? show_color = true : show_color = false
-
-
-    for node = 1:nv(g)
-        childs = Graphs.inneighbors(g, node)
-
-        for kid in childs
-            # get edge specific attributes:
-            par = "-"
-            e_attrs = _parse_attributes(attrs, "E$node$par$kid")
-
-            # automatic color if components color
-            if show_color && (colors[node] > 0) && (colors[kid] > 0)
-                (!isempty(e_attrs)) ? e_attrs = e_attrs * "," : e_attrs = "["
-                e_attrs = e_attrs * "color=$(colors[node])"
-            end
-
-            # show path in "red" for i.e. shortest path:
-            if show_path && !Base.isnothing(findfirst(isequal(node), path)) && !Base.isnothing(findfirst(isequal(kid), path)) && (kid != path[1])
-                (!isempty(e_attrs)) ? e_attrs = e_attrs * "," : e_attrs = "["
-                e_attrs = e_attrs * "color=red"
-            end
-
-            # edge labels:
-            if edge_label
-                w = g.weights[node, kid]
-                (!isempty(e_attrs)) ? e_attrs = e_attrs * "," : e_attrs = "["   # e_attrs = e_attrs * "]"
-                write(stream, "$node$(_edge_op(g))$kid $e_attrs xlabel=$w];\n")
-            else
-                (!isempty(e_attrs)) ? e_attrs = e_attrs * "]" : nothing
-                write(stream, "$node$(_edge_op(g))$kid $e_attrs;\n")
-            end
-
-        end
-
-    end
-
-
-end
-
-# internal function DOT-Language representation:
-function _to_dot(mat::AbstractSimpleWeightedGraph, stream::IO, attrs::AttributeDict, path, colors)
+    set!(attrs.node_options, "colorscheme", "set19")
 
     # standard colorscheme (max 9)
-    if (!_is_all_zero(colors))  # ToDo: no hardcoded part!!!!
+    if (!is_all_zero(colors))  # ToDo: no hardcoded part!!!!
         if maximum(colors) > 9
             colors = _reduce_colors!(colors)
         end
     end
 
-    # write Header an Graph Attributes:
-    _to_dot_graph_attributes(mat, stream, attrs)
-
-    # write Node Attributes
-    _to_dot_node_attributes(mat, stream, attrs, path, colors)
-
-    #write Edge Attributes
-    _to_dot_edge_attributes(mat, stream, attrs, path, colors)
+    for node in attrs.nodes
+        if colors[node.id] > 0
+            set!(node.attributes, "color", colors[node.id])
+        end
+    end
+end
 
 
-    write(stream, "}\n")
-    return stream
+function color_path!(attrs::GraphvizAttributes, path, g::AbstractSimpleWeightedGraph; color = "red")
+
+    for node = 1:nv(g)
+        childs = Graphs.inneighbors(g, node)
+
+        if !Base.isnothing(findfirst(isequal(node), path))
+            set_node!(attrs.nodes, node, Property("style", "filled"))
+            set_node!(attrs.nodes, node, Property("fillcolor", color))
+            for kid in childs
+                if !Base.isnothing(findfirst(isequal(kid), path)) && (kid != path[1])
+                    set_edge!(attrs.edges, node, kid, Property("color", color))
+                end
+            end
+        end
+    end
 end
 
 # helper function to reduze colors 
@@ -195,30 +139,4 @@ function _reduce_colors!(components)
 
     return components = co
 end
-
-# internal function to get `G`raph, `E`dge and `N`ode relateted attributes:
-function _get_GNE_attributes(attrs::AttributeDict, gne::String)
-    if !isempty(attrs)
-        GNE_attrs = AttributeDict()
-        for key in keys(attrs)
-            if key[2] == gne
-                GNE_attrs[key] = attrs[key]
-            end
-        end
-        return GNE_attrs
-    else
-        return ""
-    end
-end
-
-# internal function to get the dot representation of a graph as a string.
-function _to_dot(graph::AbstractSimpleWeightedGraph, attributes::AttributeDict = get_attributes(graph), path = [], colors = zeros(Int, nv(g)))
-    str = IOBuffer()
-    _to_dot(graph, str, attributes, path, colors)
-    String(take!(str)) #takebuf_string(str)
-end
-
-# helper function to identify all_zero Array
-_is_all_zero(arr) = length(arr) == 0 || all(==(0), arr)
-
 

--- a/test/data/directed/biological.gv
+++ b/test/data/directed/biological.gv
@@ -1,9 +1,21 @@
 digraph g {
 	rankdir=LR;
 
-	node [shape=rpromoter colorscheme=rdbu5 color=1 style=filled fontcolor=3]; Hef1a; TRE; UAS; Hef1aLacOid;
+	{
+    node [shape=rpromoter colorscheme=rdbu5 color=1 style=filled fontcolor=3]; 
+    Hef1a; 
+    TRE; 
+    UAS; 
+    Hef1aLacOid;
+    }
 	Hef1aLacOid [label="Hef1a-LacOid"];
-	node [shape=rarrow colorscheme=rdbu5 color=5 style=filled fontcolor=3]; Gal4VP16; LacI; rtTA3; DeltamCherry;
+	{
+    node [shape=rarrow colorscheme=rdbu5 color=5 style=filled fontcolor=3]; 
+    Gal4VP16; 
+    LacI; 
+    rtTA3; 
+    DeltamCherry;
+    }
 	Gal4VP16 [label="Gal4-VP16"];	
 	product [shape=oval style=filled colorscheme=rdbu5 color=2 label=""];
 	repression [shape=oval label="LacI repression" fontcolor=black style=dotted];


### PR DESCRIPTION
Change dot parser from own implementation to [ParserCombinator DOT](https://github.com/andrewcooke/ParserCombinator.jl/blob/master/src/dot/DOT.jl).

Open to fix: DOT grammar of ParserCombinator misses lazy subgraph notation.